### PR TITLE
Allow rules to be written in TypeScript

### DIFF
--- a/.eslintrc-multiple-rulesdir.js
+++ b/.eslintrc-multiple-rulesdir.js
@@ -13,7 +13,7 @@ if (!fs.existsSync(SYMLINK_LOCATION)) {
   fs.symlinkSync(__dirname, SYMLINK_LOCATION);
 }
 
-require('.').RULES_DIR = [path.resolve('fake-rule-dir-one'), path.resolve('fake-rule-dir-two')];
+require('.').RULES_DIR = [path.resolve('fake-rule-dir-one'), path.resolve('fake-rule-dir-two'), path.resolve('fake-rule-dir-three')];
 
 module.exports = {
   extends: 'airbnb-base',
@@ -25,6 +25,7 @@ module.exports = {
     'import/no-dynamic-require': 'off',
     'rulesdir/fake-rule': 'error',
     'rulesdir/another-fake-rule': 'error',
+    'rulesdir/yet-another-fake-rule': 'error',
   },
   plugins: [PACKAGE_NAME],
 };

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+package-lock.json

--- a/fake-rule-dir-three/yet-another-fake-rule.ts
+++ b/fake-rule-dir-three/yet-another-fake-rule.ts
@@ -1,0 +1,6 @@
+// This rule doesn't do anything.
+// it only exists to make sure a rule is found and the plugin is working.
+
+'use strict';
+
+module.exports = { create: () => ({}) };

--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ const path = require('path');
 //------------------------------------------------------------------------------
 
 const cache = {};
+
+const ruleExtensions = new Set(['.js', '.cjs', '.mjs', '.ts', '.cts', '.mts']);
+
 module.exports = {
   get rules() {
     const RULES_DIR = module.exports.RULES_DIR;
@@ -29,7 +32,7 @@ module.exports = {
       const rulesObject = {};
       rules.forEach((rulesDir) => {
         fs.readdirSync(rulesDir)
-          .filter(filename => filename.endsWith('.js') || filename.endsWith('.cjs') || filename.endsWith('.mjs'))
+          .filter(filename => ruleExtensions.has(path.extname(filename)))
           .map(filename => path.resolve(rulesDir, filename))
           .forEach((absolutePath) => {
             const ruleName = path.basename(absolutePath, path.extname(absolutePath));


### PR DESCRIPTION
This plugin currently only matches rules that have extensions of .js, .cjs, and .mjs, which means that if you want to write your rules using TypeScript, they will not be found.

To support this, I am adding the .ts, .cts, and .mts extensions to the set of extensions to match on in the rules dir. Now that the list of extensions has grown to six, it seems appropriate to additionally do a small refactoring to move the list of supported extensions to a Set that can be checked at once instead of repeatedly calling `.endsWith`.

I also added package-lock.json to the .gitignore file, since it appeared when I was getting this repo set up and it seems appropriate to mark it as an ignored file so it does not get accidentally committed later on.

Fixes #7 