### PR TITLE
Allow to load rules from subdirectories

### DIFF
--- a/.eslintrc-multiple-rulesdir.js
+++ b/.eslintrc-multiple-rulesdir.js
@@ -26,6 +26,7 @@ module.exports = {
     'rulesdir/fake-rule': 'error',
     'rulesdir/another-fake-rule': 'error',
     'rulesdir/yet-another-fake-rule': 'error',
+    'rulesdir/a-fake-directory-rule': 'error',
   },
   plugins: [PACKAGE_NAME],
 };

--- a/fake-rule-dir-three/a-fake-directory-rule/index.ts
+++ b/fake-rule-dir-three/a-fake-directory-rule/index.ts
@@ -1,0 +1,6 @@
+// This rule doesn't do anything.
+// it only exists to make sure a rule is found and the plugin is working.
+
+'use strict';
+
+module.exports = { create: () => ({}) };

--- a/fake-rule-dir-three/unrelated-dir.ts/index.ts
+++ b/fake-rule-dir-three/unrelated-dir.ts/index.ts
@@ -1,0 +1,1 @@
+export const foo = 2;

--- a/index.js
+++ b/index.js
@@ -39,7 +39,9 @@ module.exports = {
             if (rulesObject[ruleName]) {
               throw new Error(`eslint-plugin-rulesdir found two rules with the same name: ${ruleName}`);
             }
-            rulesObject[ruleName] = require(absolutePath);
+            if (entry.isFile()) {
+              rulesObject[ruleName] = require(absolutePath);
+            }
           });
       });
       cache[cacheKey] = rulesObject;

--- a/index.js
+++ b/index.js
@@ -31,10 +31,10 @@ module.exports = {
       const rules = Array.isArray(RULES_DIR) ? RULES_DIR : [RULES_DIR];
       const rulesObject = {};
       rules.forEach((rulesDir) => {
-        fs.readdirSync(rulesDir)
-          .filter(filename => ruleExtensions.has(path.extname(filename)))
-          .map(filename => path.resolve(rulesDir, filename))
-          .forEach((absolutePath) => {
+        fs.readdirSync(rulesDir, { withFileTypes: true })
+          .filter(entry => ruleExtensions.has(path.extname(entry.name)))
+          .forEach((entry) => {
+            const absolutePath = path.resolve(rulesDir, entry.name);
             const ruleName = path.basename(absolutePath, path.extname(absolutePath));
             if (rulesObject[ruleName]) {
               throw new Error(`eslint-plugin-rulesdir found two rules with the same name: ${ruleName}`);


### PR DESCRIPTION
When a custom rule grows, it becomes clumsy to keep it in one file. Moving it into a subdirectory still requires an entry file, resulting in two similar, but distinct names in the custom rules directory.

This PR allows a shape of module directories that’s native to Node.js packages: a subdirectory with an index.js file in it.
